### PR TITLE
Update mtu1280d.c to fix gcc warnings

### DIFF
--- a/mtu1280d.c
+++ b/mtu1280d.c
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <netinet/ip.h>
@@ -81,7 +82,7 @@ typedef struct fullframe {
 int
 sockfd(void)
 {
-	static		sock = 0;
+	static int sock = 0;
 	if (!sock) {
 		sock = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW);
 	};


### PR DESCRIPTION
mtu1280d.c: In function 'sockfd':
mtu1280d.c:84:25: warning: type defaults to 'int' in declaration of 'sock' [-Wimplicit-int]
mtu1280d.c: In function 'macaddr_for_interface':
mtu1280d.c:117:64: warning: implicit declaration of function 'ioctl' [-Wimplicit-function-declaration]