### PR TITLE
Improve error messages for ioctl() and sendto()

### DIFF
--- a/mtu1280d.c
+++ b/mtu1280d.c
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <netinet/ip.h>
@@ -81,7 +82,7 @@ typedef struct fullframe {
 int
 sockfd(void)
 {
-	static		sock = 0;
+	static int sock = 0;
 	if (!sock) {
 		sock = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW);
 	};

--- a/mtu1280d.c
+++ b/mtu1280d.c
@@ -48,12 +48,12 @@ unsigned int	do_debug = 0;	/* -g */
 unsigned int    do_watchdog = 0; /* -w */
 unsigned int    do_watchdog_times = 10; /* -W */
 
-void must(char *s, int i)
+void must(char *label, int successful)
 {
-	if (i == 0)
-		printf("must: %s (value %s)\n", s, i ? "true" : "false");
-	if (!i)
+	if (!successful) {
+		fprintf(stderr, "%s failed: %s\n", label, strerror(errno));
 		exit(1);
+	}
 }
 
 
@@ -107,7 +107,7 @@ macaddr_for_interface(int i)
 		struct ifreq	ifr;
 
 		if (interface) {
-			debugf("Looked up %d, found %s ", i, interface);
+			debugf("Looked up %d, found %s\n", i, interface);
 
 			/*
 			 * Use ioctl() to look up interface name and get its
@@ -121,7 +121,7 @@ macaddr_for_interface(int i)
 		};
 
 	};
-	debugf("interface %d mac %02x:%02x:%02x:%02x:%02x:%02x",
+	debugf("interface %d mac %02x:%02x:%02x:%02x:%02x:%02x\n",
 	i, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], buffer[5]);
 
 	return buffer;
@@ -346,7 +346,7 @@ block_pkt(struct nfq_data *tb)
 
 	int		tx_len = ETHER_SIZE + IPV6HDR_SIZE + ICMP6_SIZE + copy_len;
 	if (sendto(sockfd(), &buffer, tx_len, 0, (struct sockaddr *)&socket_address, sizeof(struct sockaddr_ll)) < 0)
-		printf("Send failed\n");
+		perror("sendto() failed");
 
 	debugf("trace during reject: returning NF_DROP\n");
 


### PR DESCRIPTION
this patch builds on #7 by making ioctl() and sendto() failures print the actual error, and cleans up the nearby logging so that the error messages are on their own line. i was seeing failures in those calls due to a bug in sockfd(), which i’ll fix in my next patch.

ioctl() error before:

```
$ sudo ./mtu1280d -g
DEBUG: mtu1280d.c:468 main(): trace
DEBUG: mtu1280d.c:484 main(): calling recv()
DEBUG: mtu1280d.c:492 main(): recv()  rv=1588 errno=0
DEBUG: mtu1280d.c:264 block_pkt(): Rejecting! 1500 bytes
DEBUG: mtu1280d.c:110 macaddr_for_interface(): Looked up 24, found bridge13 must: ioctl() for source MAC address (value false)
```

ioctl() error after:

```
[...]
DEBUG: mtu1280d.c:264 block_pkt(): Rejecting! 1500 bytes
DEBUG: mtu1280d.c:110 macaddr_for_interface(): Looked up 24, found bridge13
must: ioctl() for source MAC address failed: Inappropriate ioctl for device
```

sendto() error before:

```
[...]
DEBUG: mtu1280d.c:275 block_pkt(): Rejecting! 1500 bytes
DEBUG: mtu1280d.c:110 macaddr_for_interface(): Looked up 24, found bridge13 DEBUG: mtu1280d.c:135 macaddr_for_interface(): interface 24 mac ce:cc:ff:ee:46:8bDEBUG: mtu1280d.c:356 block_pkt(): trace during reject: calling sendto()
Send failed
DEBUG: mtu1280d.c:362 block_pkt(): trace during reject: returning NF_DROP
DEBUG: mtu1280d.c:495 main(): calling recv()
```

sendto() error after:

```
[...]
DEBUG: mtu1280d.c:275 block_pkt(): Rejecting! 1500 bytes
DEBUG: mtu1280d.c:110 macaddr_for_interface(): Looked up 24, found bridge13
DEBUG: mtu1280d.c:135 macaddr_for_interface(): Interface 24 mac ce:cc:ff:ee:46:8b
DEBUG: mtu1280d.c:356 block_pkt(): trace during reject: calling sendto()
sendto() failed: Socket operation on non-socket
DEBUG: mtu1280d.c:362 block_pkt(): trace during reject: returning NF_DROP
DEBUG: mtu1280d.c:495 main(): calling recv()
```