### PR TITLE
Fix bug where sockfd() may return wrong file descriptor

### DIFF
--- a/mtu1280d.c
+++ b/mtu1280d.c
@@ -21,6 +21,7 @@
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#include <sys/ioctl.h>
 #include <arpa/inet.h>
 #include <net/if.h>
 #include <netinet/ip.h>
@@ -81,7 +82,7 @@ typedef struct fullframe {
 int
 sockfd(void)
 {
-	static		sock = 0;
+	static int sock = 0;
 	if (!sock) {
 		sock = socket(AF_PACKET, SOCK_RAW, IPPROTO_RAW);
 	};

--- a/mtu1280d.c
+++ b/mtu1280d.c
@@ -48,12 +48,12 @@ unsigned int	do_debug = 0;	/* -g */
 unsigned int    do_watchdog = 0; /* -w */
 unsigned int    do_watchdog_times = 10; /* -W */
 
-void must(char *s, int i)
+void must(char *label, int successful)
 {
-	if (i == 0)
-		printf("must: %s (value %s)\n", s, i ? "true" : "false");
-	if (!i)
+	if (!successful) {
+		fprintf(stderr, "must: %s failed: %s\n", label, strerror(errno));
 		exit(1);
+	}
 }
 
 
@@ -107,7 +107,7 @@ macaddr_for_interface(int i)
 		struct ifreq	ifr;
 
 		if (interface) {
-			debugf("Looked up %d, found %s ", i, interface);
+			debugf("Looked up %d, found %s\n", i, interface);
 
 			/*
 			 * Use ioctl() to look up interface name and get its
@@ -121,7 +121,7 @@ macaddr_for_interface(int i)
 		};
 
 	};
-	debugf("interface %d mac %02x:%02x:%02x:%02x:%02x:%02x",
+	debugf("Interface %d mac %02x:%02x:%02x:%02x:%02x:%02x\n",
 	i, buffer[0], buffer[1], buffer[2], buffer[3], buffer[4], buffer[5]);
 
 	return buffer;
@@ -346,7 +346,7 @@ block_pkt(struct nfq_data *tb)
 
 	int		tx_len = ETHER_SIZE + IPV6HDR_SIZE + ICMP6_SIZE + copy_len;
 	if (sendto(sockfd(), &buffer, tx_len, 0, (struct sockaddr *)&socket_address, sizeof(struct sockaddr_ll)) < 0)
-		printf("Send failed\n");
+		perror("sendto() failed");
 
 	debugf("trace during reject: returning NF_DROP\n");
 

--- a/mtu1280d.c
+++ b/mtu1280d.c
@@ -89,6 +89,7 @@ sockfd(void)
 	if (sock == -1) {
 		perror("socket");
 	};
+	return sock;
 }
 
 uint8_t        *


### PR DESCRIPTION
sockfd() has no return statement, so on my machine, it returns 0, which is not the fd returned by socket(). this can make sendto() fail with ENOTSOCK:

```
$ sudo ./mtu1280d -g
DEBUG: mtu1280d.c:479 main(): trace
DEBUG: mtu1280d.c:495 main(): calling recv()
DEBUG: mtu1280d.c:503 main(): recv()  rv=1588 errno=0
DEBUG: mtu1280d.c:275 block_pkt(): Rejecting! 1500 bytes
DEBUG: mtu1280d.c:110 macaddr_for_interface(): Looked up 24, found bridge13
DEBUG: mtu1280d.c:135 macaddr_for_interface(): Interface 24 mac ce:cc:ff:ee:46:8b
DEBUG: mtu1280d.c:356 block_pkt(): trace during reject: calling sendto()
sendto() failed: Socket operation on non-socket
DEBUG: mtu1280d.c:362 block_pkt(): trace during reject: returning NF_DROP
DEBUG: mtu1280d.c:495 main(): calling recv()
```
```
$ sudo strace ./mtu1280d -g
[...]
socket(AF_PACKET, SOCK_RAW, htons(0xff00 /* ETH_P_??? */)) = 4
[...]
sendto(0, "\316\314\377\356\200#\316\314\377\356F\213\206\335`\0\0\0\4\330:\377$\3X\16\2\24\0\0\0\0"..., 1294, 0, {sa_family=AF_UNSPEC, sa_data="\0\0\30\0\0\0\0\0\0\6\316\314\377\356\200#\0\0"}, 20) = -1 ENOTSOCK (Socket operation on non-socket)
```

this patch builds on #7 and #8, fixing that bug by adding the return statement:

```
[...]
DEBUG: mtu1280d.c:357 block_pkt(): trace during reject: calling sendto()
DEBUG: mtu1280d.c:363 block_pkt(): trace during reject: returning NF_DROP
```
```
[...]
socket(AF_PACKET, SOCK_RAW, htons(0xff00 /* ETH_P_??? */)) = 4
[...]
sendto(4, "\316\314\377\356\200#\316\314\377\356F\213\206\335`\0\0\0\4\330:\377$\3X\16\2\24\0\0\0\0"..., 1294, 0, {sa_family=AF_UNSPEC, sa_data="\0\0\30\0\0\0\0\0\0\6\316\314\377\356\200#\0\0"}, 20) = 1294
```